### PR TITLE
Upgrade rice dependency for Ruby 2

### DIFF
--- a/rbplusplus.gemspec
+++ b/rbplusplus.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "rbplusplus"
-  s.version = "1.2.1"
+  s.version = "1.2.2"
   s.license = "MIT"
   s.summary = 'Ruby library to generate Rice wrapper code'
   s.homepage = 'http://rbplusplus.rubyforge.org'
@@ -13,8 +13,8 @@ Rb++ combines the powerful query interface of rbgccxml and the Rice library to
 make Ruby wrapping extensions of C++ libraries easier to write than ever.
   END
 
-  s.add_dependency "rbgccxml", "~> 1.0.0"
-  s.add_dependency "rice", "~> 2.1.0"
+  s.add_dependency "rbgccxml", "~> 1.0"
+  s.add_dependency "rice", "~> 2.1"
 
   patterns = [
     'TODO',

--- a/rbplusplus.gemspec
+++ b/rbplusplus.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "rbplusplus"
-  s.version = "1.2.2"
+  s.version = "1.3.0"
   s.license = "MIT"
   s.summary = 'Ruby library to generate Rice wrapper code'
   s.homepage = 'http://rbplusplus.rubyforge.org'

--- a/rbplusplus.gemspec
+++ b/rbplusplus.gemspec
@@ -14,7 +14,7 @@ make Ruby wrapping extensions of C++ libraries easier to write than ever.
   END
 
   s.add_dependency "rbgccxml", "~> 1.0.0"
-  s.add_dependency "rice", "~> 1.6.0"
+  s.add_dependency "rice", "~> 2.1.0"
 
   patterns = [
     'TODO',


### PR DESCRIPTION
Upgrading the dependency to rice 2.1 made rbplusplus to work again in Ruby 2 (2.3.0) for me.