### PR TITLE
Update to work with RbGCCXML 1.1 and CastXML

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,16 @@
-before_install:
-  - gem install bundler
+language: ruby
 before_script:
   - sudo apt-get update
-  - sudo apt-get install gccxml
-  - gem uninstall -a --force gccxml_gem
-  - gem install gccxml_gem --platform ruby
+  - sudo apt-get install cmake
+  - git clone https://github.com/CastXML/CastXML.git
+  - mkdir CastXMLBuild
+  - cd CastXMLBuild
+  - cmake ../CastXML
+  - make
+  - export PATH=$PWD/bin:$PATH
+  - cd ..
 rvm:
   - 2.1.0
   - 2.2.0
   - 2.3.0
-  - ruby-head
-matrix:
-  allow_failures:
-    - rvm: ruby-head
+  - 2.4.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: ruby
-before_script:
+before_install:
   - sudo apt-get update
   - sudo apt-get install cmake
+  - gem install bundler
   - git clone https://github.com/CastXML/CastXML.git
   - mkdir CastXMLBuild
   - cd CastXMLBuild
@@ -10,7 +11,6 @@ before_script:
   - export PATH=$PWD/bin:$PATH
   - cd ..
 rvm:
-  - 2.1.0
-  - 2.2.0
-  - 2.3.0
-  - 2.4.0
+  - 2.2
+  - 2.3
+  - 2.4

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,6 @@ source "http://rubygems.org"
 
 gemspec
 
-gem "rbgccxml", github: "jasonroelofs/rbgccxml", branch: "castxml"
-
 group :development do
   gem "rake"
   gem "rspec", "~> 2.9.0"

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source "http://rubygems.org"
 
 gemspec
 
+gem "rbgccxml", github: "jasonroelofs/rbgccxml", branch: "castxml"
+
 group :development do
   gem "rake"
   gem "rspec", "~> 2.9.0"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ many thanks to Roman for his work, the major inspiration for this library.
 == Requirements
 
 * rbgccxml
-* rice (http://rice.rubyforge.org)
+* rice (http://jasonroelofs.github.io/rice)
 
 == Installation
 

--- a/README.md
+++ b/README.md
@@ -1,29 +1,24 @@
-== What is rb++?
+## What is rb++?
 
-Rb++ makes it almost trivially easy to create Ruby extensions for any C++
-C++ library. In the simplest of cases, there is no need to ever
-touch C++, everything is done in a very simple and clean Ruby API.
+Rb++ lets you create Ruby extensions for any C++ library. In the simplest of cases, there is no need to ever touch C++, everything is done in Ruby.
 
 For wrapping plain C libraries, I highly recommend FFI: http://github.com/ffi/ffi
 
-Note: For those familiar with py++, the similarities are minimal.
-Outside of the purpose of both libraries, rb++ was built from scratch to
-provide a Ruby-esque query and wrapping API instead of being a port. However,
-many thanks to Roman for his work, the major inspiration for this library.
+Note: For those familiar with py++, the similarities are minimal. Outside of the purpose of both libraries, rb++ was built from scratch to provide a Ruby-esque query and wrapping API instead of being a port. However, many thanks to Roman for his work, the major inspiration for this library.
 
-== Requirements
+## Requirements
 
 * rbgccxml
 * rice (http://jasonroelofs.github.io/rice)
 
-== Installation
+## Installation
 
-Rice builds and installs on any *nix system, including Mac OS X. 
+Rice builds and installs on any *nix system, including Mac OS X.
 Rice and rb++ have been shown to work under Cygwin and MinGW / MSYS.
 
-  gem install rbplusplus
+    gem install rbplusplus
 
-== The Project
+## The Project
 
 Rb++'s source is in a git repository hosted on github:
 
@@ -31,339 +26,354 @@ http://github.com/jasonroelofs/rbgplusplus/tree/master
 
 Clone with:
 
-  git clone git://github.com/jasonroelofs/rbplusplus.git
+    git clone git://github.com/jasonroelofs/rbplusplus.git
 
-== Getting Started
+## Getting Started
 
 All rb++ projects start off with the Extension class:
 
-  require 'rbplusplus'
-  include RbPlusPlus
+```ruby
+require 'rbplusplus'
+include RbPlusPlus
 
-  Extension.new "extension_name"
+Extension.new "extension_name"
+```
 
-Rb++ has one requirement on the C++ code: it must be wrapped in a namespace. If the code
-you're trying to wrap is not in it's own namespace, please build a seperate header file that
-wraps everything in a namespace as such:
+Rb++ has one requirement on the C++ code: it must be wrapped in a namespace. If the code you're trying to wrap is not in it's own namespace, please build a seperate header file that wraps everything in a namespace as such:
 
-  namespace to_wrap {
-    #include "file1.h"
-    #include "file2.h"
-    #include "file3.h"
-    ...
-  }
+```c++
+namespace to_wrap {
+  #include "file1.h"
+  #include "file2.h"
+  #include "file3.h"
+  ...
+}
+```
 
-Extension has two ways of being used: block syntax for simple projects and immediate
-syntax for more control over the whole process.
+Extension has two ways of being used: block syntax for simple projects and immediate syntax for more control over the whole process.
 
-=== Block Mode
+### Block Mode
 
 For most extension wrapping needs, Block Mode takes care of automating everything that it can:
 
-  Extension.new "extension" do |e|
-    ...
-  end
-
-=== Immediate Mode
-
-For those that want more fine-grained control over the parsing / building / writing / compiling
-process, immediate syntax is also available
-
-  e = Extension.new "extension"
+```ruby
+Extension.new "extension" do |e|
   ...
-  e.build    # => Generates the C++ code
-  e.write    # => Writes out to files
-  e.compile  # => Compiles the extension
+end
+```
 
-Please note the ##build ##write and ##compile methods. These are required for an extension to be
-built and must be called in this order. These calls are made automatically in Block Mode.
-See the RbPlusPlus::Extension class for more details.
+### Immediate Mode
 
-== Basic Usage
+For those that want more fine-grained control over the parsing / building / writing / compiling process, immediate syntax is also available
 
-For the most basic usage, there are only two required calls: Extension.sources and
-Extension.namespace. Extension.sources has a few ways to be called
-(which takes most the same parameters as RbGCCXML.parse):
+```ruby
+e = Extension.new "extension"
+...
+e.build    # => Generates the C++ code
+e.write    # => Writes out to files
+e.compile  # => Compiles the extension
+```
 
-  # A single header file
-  Extension.new "extension" do |e|
-    e.sources "/path/to/header.h"
+Please note the `#build`, `#write`, and `#compile` methods. These are required for an extension to be built and must be called in this order. These calls are made automatically in Block Mode.  See the RbPlusPlus::Extension class for more details.
+
+## Basic Usage
+
+For the most basic usage, there are only two required calls: `Extension.sources` and `Extension.namespace`. `Extension.sources` has a few ways to be called (which takes most the same parameters as `RbGCCXML.parse`):
+
+```ruby
+# A single header file
+Extension.new "extension" do |e|
+  e.sources "/path/to/header.h"
+end
+
+# An array of header files
+Extension.new "extension" do |e|
+  e.sources ["/path/to/header.h", "/path/there.h"]
+end
+
+# A glob
+Extension.new "extension" do |e|
+  e.sources "/path/to/*.h"
+end
+
+# An array of globs
+Extension.new "extension" do |e|
+  e.sources ["/path/to/*.h", "/elsewhere/*.hpp"]
+end
+```
+
+Once your sources are defined, you need to tell rb++ the name of the namespace from which code needs to be wrapped. This is done using the `#namespace` method in one of two different situations:
+
+```ruby
+# Wrap all code under the 'to_wrap' namespace
+Extension.new "extension" do |e|
+  e.namespace "to_wrap"
+end
+```
+
+When wrapping code under ruby modules, you specify which namespace should be wrapped into which module as so:
+
+```ruby
+# Wrap all code under the 'to_wrap' namespace
+Extension.new "extension" do |e|
+  e.module "ExtMod" do |m|
+    m.namespace "to_wrap"
   end
 
-  # An array of header files
-  Extension.new "extension" do |e|
-    e.sources ["/path/to/header.h", "/path/there.h"]
+  e.module "Util" do |m|
+    m.namespace "to_wrap_util"
   end
+end
+```
 
-  # A glob
-  Extension.new "extension" do |e|
-    e.sources "/path/to/*.h"
+The general rule is this: If you want C++ code wrapped, you must use `Extension#namespace` to specify where your C++ code will get wrapped.
+
+When working in Immediate Mode, there is one more required method after `#sources` and `#namespace`: `#working_dir=`, which you use to specify which directory to write out the Rice source code.  When using Block Mode, rb++ can figure out a good default working directory due to `__FILE__` on the block's binding. Without this block, rb++ is clueless and must be told where it's working directory should be:
+
+```ruby
+e = Extension.new "extension"
+e.working_dir = "/path/to/generate/files/"
+```
+
+## More Detailed Usage
+
+Because C++ does not easily wrap into Ruby code for many reasons, rb++ is much more capable than just the basic usage above. There are many different features available to help define and build the wrapper.
+
+### Modules
+
+An extension can include modules in which code will be wrapped. Any given module needs to either be given a `#namespace` call or be directly given code nodes to wrap using `Module#includes`.  This specifies which C++ code will be wrapped into this module.
+
+```ruby
+Extension.new "extension" do |e|
+  e.sources ...
+  # If there is no global-space code to be wrapped
+  # #namespace is not required here
+
+  e.module "MyModule" do |m|
+    # We want to wrap all code in ::my_module into this ruby module
+    m.namespace "my_module"
   end
+end
+```
 
-  # An array of globs
-  Extension.new "extension" do |e|
-    e.sources ["/path/to/*.h", "/elsewhere/*.hpp"]
-  end
+### Particularly hairy APIs
 
-Once your sources are defined, you need to tell rb++ the name of the namespace from which
-code needs to be wrapped. This is done using the #namespace command in one of two different
-situations:
+It's well known that source code may not follow a very clean format, or even be internally consistent.  When dealing with such problems -- code that just won't adhere to a wrappable format -- rb++ opens up a slew of manipulation routines for controlling exactly what gets wrapped, where it gets wrapped, and how it gets wrapped.
 
-  # Wrap all code under the 'to_wrap' namespace
-  Extension.new "extension" do |e|
-    e.namespace "to_wrap"
-  end
+#### Ignoring
 
-When wrapping code under ruby modules, you specify which namespace should be wrapped into
-which module as so:
+Often times you will want to ignore a method on an object, a whole class, or a whole namespace even.  This can be useful if the function you wish to ignore takes a 'void *' as an argument, or for a variety of other reasons.
 
-  # Wrap all code under the 'to_wrap' namespace
-  Extension.new "extension" do |e|
-    e.module "ExtMod" do |m|
-      m.namespace "to_wrap"
-    end
+You can tell rb++ which namespaces/classes/methods to ignore with `#ignore`:
 
-    e.module "Util" do |m|
-      m.namespace "to_wrap_util"
-    end
-  end
-
-The general rule is this: If you want C++ code wrapped, you must use Extension#namespace to specify
-where your C++ code will get wrapped.
-
-When working in Immediate Mode, there is one more required method after ##sources and ##namespace:
-##working_dir=, which you use to specify which directory to write out the Rice source code.
-When using Block Mode, rb++ can figure out a good default working directory due to __FILE__ on the
-block's binding. Without this block, rb++ is clueless and must be told where it's working directory
-should be:
-
-  e = Extension.new "extension"
-  e.working_dir = "/path/to/generate/files/"
-
-== More Detailed Usage
-
-Because C++ does not easily wrap into Ruby code for many reasons, rb++ is much more capable than just
-the basic usage above. There are many different features available to help define and build the wrapper.
-
-=== Modules
-
-An extension can include modules in which code will be wrapped. Any given module needs to either be given
-a ##namespace call or be directly given code nodes to wrap using Module#includes.
-This specifies which C++ code will be wrapped into this module.
-
-  Extension.new "extension" do |e|
-    e.sources ...
-    # If there is no global-space code to be wrapped
-    # #namespace is not required here
-
-    e.module "MyModule" do |m|
-      # We want to wrap all code in ::my_module into this ruby module
-      m.namespace "my_module"
-    end
-  end
-
-=== Particularly hairy APIs
-
-It's well known that source code may not follow a very clean format, or even be internally consistent.
-When dealing with such problems -- code that just won't adhere to a wrappable format -- rb++ opens up a slew
-of manipulation routines for controlling exactly what gets wrapped, where it gets wrapped, and how
-it gets wrapped.
-
-==== Ignoring
-
-Often times you will want to ignore a method on an object, a whole class, or a whole namespace even.  This
-can be useful if the function you wish to ignore takes a 'void *' as an argument, or for a variety of other
-reasons.
-
-You can tell rb++ which namespaces/classes/methods to ignore very easily:
-
-  Extension.new "extension" do |e|
-    e.sources ...
-    node = e.namespace "Physics"
-    node.classes("Callback").ignore                           # Ignore classes named Callback
-    node.classes("Shape").methods("registerCallback").ignore  # Ignore the method Shape::registerCallback
-  end
+```ruby
+Extension.new "extension" do |e|
+  e.sources ...
+  node = e.namespace "Physics"
+  node.classes("Callback").ignore                           # Ignore classes named Callback
+  node.classes("Shape").methods("registerCallback").ignore  # Ignore the method Shape::registerCallback
+end
+```
 
 You can also ignore a whole set of query results with the same notation:
 
 
-  Extension.new "extension" do |e|
-    ...
-    node.methods.find(:all, :name => "free").ignore           # Ignores all instance methods named 'free'
-    ...
-  end
+```ruby
+Extension.new "extension" do |e|
+  ...
+  node.methods.find(:all, :name => "free").ignore           # Ignores all instance methods named 'free'
+  ...
+end
+```
 
-==== Including
+#### Including
 
-For more control over exactly where a given piece of C++ code will be wrapped, use Module#includes:
+For more control over exactly where a given piece of C++ code will be wrapped, use `Module#includes`:
 
-  Extension.new "extension" do |e|
-    e.sources ...
-    node = e.namespace "PhysicsMath"
+```ruby
+Extension.new "extension" do |e|
+  e.sources ...
+  node = e.namespace "PhysicsMath"
 
-    e.module "Physics" do |m|
-      m.module "Math" do |math|
-        # Moves each class in ::PhysicsMath to Physics::Math.
-        # Not the best example but gets the point across. The proper
-        # way to do this is to do math.namespace "PhysicsMath" here
-        node.classes.each do |c|
-          math.includes c
-        end
+  e.module "Physics" do |m|
+    m.module "Math" do |math|
+      # Moves each class in ::PhysicsMath to Physics::Math.
+      # Not the best example but gets the point across. The proper
+      # way to do this is to do math.namespace "PhysicsMath" here
+      node.classes.each do |c|
+        math.includes c
       end
     end
-
   end
 
-Note that when you include something in a module it is moved from it's original location.  In the example above
-the classes will only exist in Physics::Math and will no longer show up in the global space.
+end
+```
 
-==== Renaming
+Note that when you include something in a module it is moved from it's original location.  In the example above the classes will only exist in `Physics::Math` and will no longer show up in the global space.
 
-Sometimes C++ libraries implement certain architectures that are nice to have in C++, but are terrible in Ruby, 
-or standards in Ruby aren't possible in C++ (func?, func=, func!). For this reason, every node can be renamed using
-the #wrap_as method:
+#### Renaming
 
-  Extension.new "extension" do |e|
-    e.sources ...
-    node = e.namespace "Physics"
-    node.classes("CShape").wrap_as("Shape")
-    node.classes("CShape").methods("hasCollided").wrap_as("collided?")
-  end
+Sometimes C++ libraries implement certain architectures that are nice to have in C++, but are terrible in Ruby, or standards in Ruby aren't possible in C++ (func?, func=, func!). For this reason, every node can be renamed using the `#wrap_as` method:
 
-Note: <b>rb++ automatically underscores all method names and CamelCases all class names that haven't been 
-otherwise changed with ##wrap_as</b>.
+```ruby
+Extension.new "extension" do |e|
+  e.sources ...
+  node = e.namespace "Physics"
+  node.classes("CShape").wrap_as("Shape")
+  node.classes("CShape").methods("hasCollided").wrap_as("collided?")
+end
+```
 
-==== Function / Method Conversions
+Note: rb++ automatically underscores all method names and CamelCases all class names that haven't been otherwise changed with `#wrap_as`.
+
+#### Function / Method Conversions
 
 C++ APIs can also sometimes expose global functionality you want contained in a class or module. This
-kind of wrapping is also trivially easy in rb++. Say you have the function:
+kind of wrapping is also possible in rb++. Say you have the function:
 
-  inline int mod(int a, int b) {
-    return a%b;
-  }
+```c
+inline int mod(int a, int b) {
+  return a%b;
+}
+```
 
-and you want to add it to your Math class as an instance method. Simple, use ##as_instance_method and ##includes:
+and you want to add it to your Math class as an instance method. Use `#as_instance_method` and `#includes`:
 
-  mod = node.functions("mod")
-  node.classes("Math").includes mod.as_instance_method
+```ruby
+mod = node.functions("mod")
+node.classes("Math").includes mod.as_instance_method
 
-  ----
+----
 
-  require 'extension'
+require 'extension'
 
-  Math.new.mod(1, 2)
+Math.new.mod(1, 2)
+```
 
-== Possible 'Gotchas'
+## Possible 'Gotchas'
 
-=== Constructor overloading
+### Constructor overloading
 
-A current limitation in rice currently does not allow for more than one constructor to be exported.  This
-will not be a limitation in future versions of Rice, but for now make sure that only one constructor is wrapped.
-This can be done via direct constructor access:
+A current limitation in rice currently does not allow for more than one constructor to be exported. This will not be a limitation in future versions of Rice, but for now make sure that only one constructor is wrapped. This can be done via direct constructor access:
 
-  node.classes("MyClass").constructors[0].ignore
+```ruby
+node.classes("MyClass").constructors[0].ignore
+```
 
 or by querying according to the arguments of the constructor(s) you want to ignore:
 
-  node.classes("MyClass").constructors.find(:arguments => [nil,  nil]) # ignore constructors with 2 arguments
+```ruby
+node.classes("MyClass").constructors.find(:arguments => [nil,  nil]) # ignore constructors with 2 arguments
+```
 
 Contrary to ignoring a constructor, you can also expliclty tell rb++ which constructor to use:
 
-  my_class = node.classes("MyClass")
-  my_class.use_constructor my_class.constructors[0]
+```ruby
+my_class = node.classes("MyClass")
+my_class.use_constructor my_class.constructors[0]
+```
 
 Rb++ will print out a (WARNING) for each class affected by this.
 
-=== Method overloading
+### Method overloading
 
-Method overloading not currently supported in Rice, thus rb++ has a workaround built in.
-All overloaded methods are wrapped in the order that they are presented to gccxml.  For example:
+Method overloading not currently supported in Rice, thus rb++ has a workaround built in. All overloaded methods are wrapped in the order that they are presented to gccxml. For example:
 
-  class System {
-    public:
-    System() {}
-    inline void puts(std::string s) { std::cout << s << std::endl; }
-    inline void puts() { puts(""); }
-  };
+```c++
+class System {
+  public:
+  System() {}
+  inline void puts(std::string s) { std::cout << s << std::endl; }
+  inline void puts() { puts(""); }
+};
+```
 
 Will be exposed by default like so:
 
-  s = System.new
-  s.puts_0("Hello world")
-  s.puts_1
+```ruby
+s = System.new
+s.puts_0("Hello world")
+s.puts_1
+```
 
 You can, however, rename them as you see fit if you tell rb++ how, for example:
 
-  puts_methods = node.classes("System").methods("puts")
-  puts_methods[0].wrap_as("puts")
+```ruby
+puts_methods = node.classes("System").methods("puts")
+puts_methods[0].wrap_as("puts")
+```
 
 After doing this you can use the methods as follows:
 
-  s = System.new
-  s.puts("Hello World")
-  s.puts_1
+```ruby
+s = System.new
+s.puts("Hello World")
+s.puts_1
+```
 
 As of right now, there isn't a specific way to say "use this method as the default name", you need to
-make sure you ##wrap_as the method you want to stay the same and let the others get the suffix.
+make sure you use `#wrap_as` on the method you want to stay the same and let the others get the suffix.
 
-== Misc Options
+## Misc Options
 
-=== File Writing Options
+### File Writing Options
 
 By default, rb++ will write out the extension in multiple files, following the convention of
 
-  extension_name.rb.cpp
-  _ClassName.rb.hpp
-  _ClassName.rb.cpp
-  _ModuleName_ClassName.rb.hpp
-  _ModuleName_ClassName.rb.cpp
-  ...
+```
+extension_name.rb.cpp
+__ClassName.rb.hpp
+__ClassName.rb.cpp
+__ModuleName_ClassName.rb.hpp
+__ModuleName_ClassName.rb.cpp
+...
+```
 
-This is done to prevent obscenely long compile times, super large code files, or uncompilable extensions due to
-system limitations (e.g. RAM) that are common problems with big SWIG projects.
+This is done to prevent obscenely long compile times, super large code files, or uncompilable extensions due to system limitations (e.g. RAM) that are common problems with big SWIG projects. Rb++ can also write out the extension code in a single file (extension_name.cpp) with `Extension#writer_mode`
 
-Rb++ can also write out the extension code in a single file (extension_name.cpp) with Extension#writer_mode
+```ruby
+Extension.new "extension" do |e|
+  e.writer_mode :single # :multiple is the default
+end
+```
 
-  Extension.new "extension" do |e|
-    e.writer_mode :single # :multiple is the default
-  end
+### Compilation options
 
-=== Compilation options
+Rb++ takes care of setting up the extension to be properly compiled, but sometimes certain compiler options can't be deduced. Rb++ has options to specify library paths (-L), libraries (-l), and include paths (-I) to add to the compilation lines, as well as just adding your own flags directly to the command line. These are options on Extension.sources
 
-Rb++ takes care of setting up the extension to be properly compiled, but sometimes certain
-compiler options can't be deduced. Rb++ has options to specify library paths (-L), libraries (-l),
-and include paths (-I) to add to the compilation lines, as well as just adding your own flags
-directly to the command line. These are options on Extension.sources
+```ruby
+Extension.new "extension" do |e|
+  e.sources *header_dirs,
+    :library_paths => *paths,       # Adds to -L
+    :libraries => *libs,            # Adds to -l
+    :include_paths => *includes,    # Adds to -I
+    :cxxflags => *flags,            # For those flags that don't match the above three
+    :ldflags => *flags,             # For extra linking flags that don't match the above
+    :includes => *files,            # For when there are header files that need to be included into the
+                                    #   compilation but *don't* get parsed and wrapped
+    :include_source_files => *files # A list of source files that will get copied into working_dir and
+                                    #   compiled with the extension
+    :include_source_dir => dir      # Specify a directory. Rb++ will build up a list of :includes and
+                                    #   :include_source_files based on the files in this directory
+end
+```
 
-  Extension.new "extension" do |e|
-    e.sources *header_dirs,
-      :library_paths => *paths,       # Adds to -L
-      :libraries => *libs,            # Adds to -l
-      :include_paths => *includes,    # Adds to -I
-      :cxxflags => *flags,            # For those flags that don't match the above three
-      :ldflags => *flags,             # For extra linking flags that don't match the above
-      :includes => *files,            # For when there are header files that need to be included into the
-                                      #   compilation but *don't* get parsed and wrapped
-      :include_source_files => *files # A list of source files that will get copied into working_dir and
-                                      #   compiled with the extension
-      :include_source_dir => dir      # Specify a directory. Rb++ will build up a list of :includes and
-                                      #   :include_source_files based on the files in this directory
-  end
-
-=== Command Line Arguments
+### Command Line Arguments
 
 Rb++ exposes a few command line arguments to your wrapper script that allow more find-grained control
 over running your script. These options are:
 
-  Usage: ruby build_noise.rb [options]
-    -h, --help                       Show this help message
-    -v, --verbose                    Show all progress messages (INFO, DEBUG, WARNING, ERROR)
-    -q, --quiet                      Only show WARNING and ERROR messages
-        --console                    Open up a console to query the source via rbgccxml
-        --clean                      Force a complete clean and rebuild of this extension
+```
+Usage: ruby build_noise.rb [options]
+  -h, --help                       Show this help message
+  -v, --verbose                    Show all progress messages (INFO, DEBUG, WARNING, ERROR)
+  -q, --quiet                      Only show WARNING and ERROR messages
+      --console                    Open up a console to query the source via rbgccxml
+      --clean                      Force a complete clean and rebuild of this extension
+```
 
-=== Logging
+### Logging
 
-All logging is simply sent straight to STDOUT except (ERROR) messages which are sent to STDERR. 
+All logging is simply sent straight to STDOUT except (ERROR) messages which are sent to STDERR.
 
 Compilation logs are found in [working_dir]/rbpp_compile.log.

--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,7 @@ task :test do
     # the exact ruby binary that's linked to the ruby running the Rakefile. Just saying
     # "ruby" will find the system's installed ruby and be worthless
     ruby = File.join(RbConfig::CONFIG["bindir"], RbConfig::CONFIG["RUBY_INSTALL_NAME"])
-    sh "#{ruby} -S rspec -Itest #{file}"
+    sh "#{ruby} -Itest -S rspec #{file}"
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,4 @@
 require 'rdoc/task'
-require 'rake/contrib/sshpublisher'
 
 task :default => :test
 
@@ -28,29 +27,4 @@ Rake::RDocTask.new do |rd|
   rd.rdoc_files.exclude("**/jamis.rb")
   rd.template = File.expand_path(File.dirname(__FILE__) + "/lib/jamis.rb")
   rd.options << '--line-numbers' << '--inline-source'
-end
-
-RUBYFORGE_USERNAME = "jameskilton"
-PROJECT_WEB_PATH = "/var/www/gforge-projects/rbplusplus"
-
-namespace :web do
-  desc "Build website"
-  task :build => :rdoc do |t|
-    unless File.directory?("publish")
-      mkdir "publish"
-    end
-
-    sh "jekyll --pygment website publish/"
-    sh "cp -r html/* publish/rbplusplus/"
-  end
-
-  desc "Update the website" 
-  task :upload => "web:build"  do |t|
-    Rake::SshDirPublisher.new("#{RUBYFORGE_USERNAME}@rubyforge.org", PROJECT_WEB_PATH, "publish").upload
-  end
-
-  desc "Clean up generated website files" 
-  task :clean do
-    rm_rf "publish"
-  end
 end

--- a/lib/rbplusplus/builders/class.rb
+++ b/lib/rbplusplus/builders/class.rb
@@ -95,7 +95,7 @@ module RbPlusPlus
       # to allocate the class directly. If this code tries to use a non-public
       # constructor, we hit a compiler error.
       def check_allocation_strategies
-        # Due to the nature of GCC-XML's handling of templated classes, there are some
+        # Due to the nature of CastXML's handling of templated classes, there are some
         # classes that might not have any gcc-generated constructors or destructors.
         # We check here if we're one of those classes and completely skip this step
         return if [self.code.constructors].flatten.empty?

--- a/lib/rbplusplus/builders/const_converter.rb
+++ b/lib/rbplusplus/builders/const_converter.rb
@@ -32,7 +32,7 @@ module RbPlusPlus
         includes << "#include \"#{self.code.file}\""
 
         declarations << "template<>"
-        declarations << "Rice::Object to_ruby<#{full_name} >(#{full_name} const & a);"
+        declarations << "Rice::Object to_ruby< #{full_name} >(#{full_name} const & a);"
 
         build_as = if self.parent.is_a?(EnumerationNode)
                      "new #{full_name}(a)"
@@ -41,8 +41,8 @@ module RbPlusPlus
                    end
 
         registrations << "template<>"
-        registrations << "Rice::Object to_ruby<#{full_name} >(#{full_name} const & a) {"
-        registrations << "\treturn Rice::Data_Object<#{full_name} >(#{build_as}, Rice::Data_Type<#{full_name} >::klass(), 0, 0);"
+        registrations << "Rice::Object to_ruby< #{full_name} >(#{full_name} const & a) {"
+        registrations << "\treturn Rice::Data_Object< #{full_name} >(#{build_as}, Rice::Data_Type< #{full_name} >::klass(), 0, 0);"
         registrations << "}"
       end
 

--- a/lib/rbplusplus/builders/enumeration.rb
+++ b/lib/rbplusplus/builders/enumeration.rb
@@ -11,7 +11,7 @@ module RbPlusPlus
         # See ClassNode
         add_global_child ConstConverterNode.new(self.code, self)
 
-        self.rice_variable_type = "Rice::Enum<#{code.qualified_name}>"
+        self.rice_variable_type = "Rice::Enum< #{code.qualified_name} >"
         self.rice_variable = "rb_e#{code.name}"
 
         Logger.info "Wrapping enumeration #{code.qualified_name}"
@@ -21,7 +21,7 @@ module RbPlusPlus
         second = parent.rice_variable ? ", #{parent.rice_variable}" : ""
 
         registrations << "\t#{rice_variable_type} #{rice_variable} = " \
-          "Rice::define_enum<#{code.qualified_name}>(\"#{code.name}\"#{second});"
+          "Rice::define_enum< #{code.qualified_name} >(\"#{code.name}\"#{second});"
 
         code.values.each do |v|
           registrations << "\t#{rice_variable}.define_value(\"#{v.name}\", #{v.qualified_name});"

--- a/lib/rbplusplus/builders/method_base.rb
+++ b/lib/rbplusplus/builders/method_base.rb
@@ -163,9 +163,10 @@ module RbPlusPlus
       # for an example.
       def fix_enumeration_value(enum, default_value)
         enum_values = [enum.values].flatten
+        just_base_name = default_value.split("::").last
         found =
           enum_values.select do |enum_value|
-            enum_value.name == default_value
+            enum_value.name == default_value || enum_value.name == just_base_name
           end.first
 
         found ? found.qualified_name : default_value

--- a/lib/rbplusplus/builders/method_base.rb
+++ b/lib/rbplusplus/builders/method_base.rb
@@ -150,7 +150,7 @@ module RbPlusPlus
 
       # See http://www.gccxml.org/Bug/view.php?id=9234
       #
-      # Basically due to inconsistencies within gcc, GCC-XML parses default arguments
+      # Basically due to inconsistencies within gcc, CastXML parses default arguments
       # with having enumeration values exactly as they are in the code. This means
       # that if the C++ doesn't fully namespace the enumeration, extension compilation
       # will fail because g++ can't find the enumeration.

--- a/rbplusplus.gemspec
+++ b/rbplusplus.gemspec
@@ -13,7 +13,7 @@ Rb++ combines the powerful query interface of rbgccxml and the Rice library to
 make Ruby wrapping extensions of C++ libraries easier to write than ever.
   END
 
-  s.add_dependency "rbgccxml", "~> 1.0"
+  s.add_dependency "rbgccxml", "~> 1.1"
   s.add_dependency "rice", "~> 2.1"
 
   patterns = [

--- a/test/allocation_strategies_test.rb
+++ b/test/allocation_strategies_test.rb
@@ -15,19 +15,13 @@ describe "Allocation Strategies" do
   # instantiate an object with a non-public constructor
   # and it all dies.
   specify "properly figures out what allocation to do" do
-    lambda do
-      require 'alloc_strats'
-    end.should_not raise_error(LoadError)
+    require 'alloc_strats'
 
     # Private constructor, public destructor
-    lambda do
-      NoConstructor
-    end.should_not raise_error(NameError)
+    NoConstructor
 
     # Private constructor and destructor
-    lambda do
-      Neither
-    end.should_not raise_error(NameError)
+    Neither
   end
 
   specify "can get access to Neither object" do

--- a/test/class_methods_encapsulate_test.rb
+++ b/test/class_methods_encapsulate_test.rb
@@ -22,7 +22,7 @@ describe "Correct handling of encapsulated methods" do
       ext.protected_method
     end.should raise_error(NoMethodError)
   end
-  
+
   specify "should handle virtual methods" do
     ext_factory = ExtendedFactory.new
     ext = ext_factory.new_instance
@@ -42,18 +42,14 @@ describe "Correct handling of encapsulated methods" do
       arg.wrap_me_protected
     end.should raise_error(NoMethodError)
 
-    lambda do
-      arg.wrap_me_public ArgumentAccess::PublicStruct.new
-    end.should_not raise_error(NoMethodError)
-    
+    arg.wrap_me_public ArgumentAccess::PublicStruct.new
+
     # Multiple argument methods
     lambda do
       arg.wrap_me_many_no
     end.should raise_error(NoMethodError)
 
-    lambda do
-      arg.wrap_me_many_yes(1, 2.0, ArgumentAccess::PublicStruct.new)
-    end.should_not raise_error(NoMethodError)
+    arg.wrap_me_many_yes(1, 2.0, ArgumentAccess::PublicStruct.new)
   end
 end
 

--- a/test/classes_test.rb
+++ b/test/classes_test.rb
@@ -104,9 +104,5 @@ describe "Extension with wrapped classes" do
     a.add_integers(3, 7).should == 21
     a.add_strings("piz", "owned").should == "pizownedwoot"
   end
-
-  specify "should not wrap incomplete types" do
-    lambda { Forwarder }.should raise_error
-  end
 end
 

--- a/test/classes_test.rb
+++ b/test/classes_test.rb
@@ -22,10 +22,6 @@ describe "Extension with wrapped classes" do
     require 'adder'
   end
 
-  specify "should make classes available as Ruby runtime constants" do
-    lambda { Adder }.should_not raise_error
-  end
-
   specify "should make wrapped classes constructable" do
     a = Adder.new
     a.should_not be_nil
@@ -46,15 +42,15 @@ describe "Extension with wrapped classes" do
   end
 
   specify "should use typedefs when findable" do
-    lambda { IntAdder }.should_not raise_error
+    IntAdder
   end
 
   specify "finds and uses multi-nested typedefs" do
-    lambda { ShouldFindMe }.should_not raise_error
+    ShouldFindMe
   end
 
   specify "can turn off typedef lookup for certain classes" do
-    lambda { DontFindMeBro }.should raise_error
+    lambda { DontFindMeBro }.should raise_error(NameError)
   end
 
   specify "makes class constants available" do
@@ -62,7 +58,7 @@ describe "Extension with wrapped classes" do
   end
 
   specify "can ignore constants" do
-    lambda { Adder::HideMe }.should raise_error
+    lambda { Adder::HideMe }.should raise_error(NameError)
   end
 
   specify "makes public instance variables accessible" do
@@ -84,7 +80,7 @@ describe "Extension with wrapped classes" do
 
     lambda do
       a.const_var = "This is a value!"
-    end.should raise_error
+    end.should raise_error(NoMethodError)
 
     a.const_var.should == 14
   end

--- a/test/compiling_test.rb
+++ b/test/compiling_test.rb
@@ -121,29 +121,25 @@ describe "Compiler settings" do
   end
 
   specify "should pass cxxflags to rbgccxml" do
-    lambda do
-      e = Extension.new "parsing_test" 
-      e.working_dir = full_dir("generated")
-      e.sources full_dir("headers/requires_define.h"),
-        :cxxflags => "-DMUST_BE_DEFINED"
-      e.build
-      e.write
-    end.should_not raise_error
+    e = Extension.new "parsing_test" 
+    e.working_dir = full_dir("generated")
+    e.sources full_dir("headers/requires_define.h"),
+      :cxxflags => "-DMUST_BE_DEFINED"
+    e.build
+    e.write
   end
 
   specify "should be able to add additional headers as needed" do
-    lambda do
-      e = Extension.new "external" 
-      e.working_dir = full_dir("generated")
-      e.sources full_dir("headers/external_mapping.h"), 
-        :includes => full_dir("headers/*rice.h")
-      e.build
-      e.write
+    e = Extension.new "external" 
+    e.working_dir = full_dir("generated")
+    e.sources full_dir("headers/external_mapping.h"), 
+      :includes => full_dir("headers/*rice.h")
+    e.build
+    e.write
 
-      file = full_dir("generated/external.rb.cpp")
-      contents = File.read(file)
-      contents.should =~ %r(headers/external_mapping_rice.h)
-    end.should_not raise_error
+    file = full_dir("generated/external.rb.cpp")
+    contents = File.read(file)
+    contents.should =~ %r(headers/external_mapping_rice.h)
   end
 
   specify "can specify other source files to be compiled into the extension" do

--- a/test/constructors_test.rb
+++ b/test/constructors_test.rb
@@ -15,14 +15,12 @@ describe "Extension with constructors out the whazoo" do
 
     require 'constructors'
 
-    lambda do
-      # Test complex constructors
-      d = DoubleStringHolder.new("one", "two")
-      one = d.get_one
-      d.get_one.should == "one"
-      d.get_two.should == "two"
-    end.should_not raise_error(NameError)
-    
+    # Test complex constructors
+    d = DoubleStringHolder.new("one", "two")
+    one = d.get_one
+    d.get_one.should == "one"
+    d.get_two.should == "two"
+
     lambda do
       PrivateConstructor.new
     end.should raise_error(TypeError)

--- a/test/director_test.rb
+++ b/test/director_test.rb
@@ -58,9 +58,7 @@ describe "Director proxy generation" do
       end
     end
 
-    lambda do
-      SuperGoodWorker.new.do_something(10).should == 50
-    end.should_not raise_error(NotImplementedError)
+    SuperGoodWorker.new.do_something(10).should == 50
   end
 
   specify "can specify a default return value in the wrapper" do
@@ -86,12 +84,12 @@ describe "Director proxy generation" do
   specify "properly adds all constructor arguments" do
     v = VirtualWithArgs.new 14, true
     v.process_a("hi").should == 16
-    v.process_b.should be_true
+    v.process_b.should eq(true)
   end
 
   specify "takes into account renamed methods / classes" do
     c = BetterNamedClass.new
-    c.x_ok?.should_not be_true
+    c.x_ok?.should_not eq(true)
 
     c.do_processing.should == 14
   end
@@ -162,9 +160,6 @@ describe "Director proxy generation" do
   end
 
   specify "multiple files writer properly handles directors and nested nodes" do
-    lambda { Worker::ZeeEnum }.should_not raise_error(NameError)
-    lambda { Worker::ZeeEnum::VALUE }.should_not raise_error(NameError)
-
     Worker::ZeeEnum::VALUE.to_i.should == 4
   end
 

--- a/test/enumerations_test.rb
+++ b/test/enumerations_test.rb
@@ -17,8 +17,6 @@ describe "Wrapping enumerations" do
   end
 
   specify "should wrap up enums properly" do
-    lambda { TestEnum }.should_not raise_error(NameError)
-
     TestEnum::VALUE1.to_i.should == 0
     TestEnum::VALUE2.to_i.should == 1
     TestEnum::VALUE3.to_i.should == 2
@@ -30,16 +28,12 @@ describe "Wrapping enumerations" do
   end
 
   specify "should wrap up enumerations at proper nesting" do
-    lambda { Tester::MyEnum }.should_not raise_error(NameError)
-
     Tester::MyEnum::I_LIKE_MONEY.to_i.should == 3
     Tester::MyEnum::YOU_LIKE_MONEY_TOO.to_i.should == 4
     Tester::MyEnum::I_LIKE_YOU.to_i.should == 7
   end
 
   specify "should work in user-defined modules" do
-    lambda { Mod::InnerEnum }.should_not raise_error(NameError)
-
     Mod::InnerEnum::INNER_1.to_i.should == 0
     Mod::InnerEnum::INNER_2.to_i.should == 1
   end
@@ -63,11 +57,6 @@ describe "Wrapping enumerations" do
   end
 
   specify "anonymous enumerations' values are added as constants to the parent class" do
-    lambda { Tester::ANON_ENUM_VAL1 }.should_not raise_error(NameError)
-    lambda { Tester::ANON_ENUM_VAL2 }.should_not raise_error(NameError)
-    lambda { Tester::ANON_ENUM_VAL3 }.should_not raise_error(NameError)
-    lambda { Tester::ANON_ENUM_VAL4 }.should_not raise_error(NameError)
-
     Tester::ANON_ENUM_VAL1.should == 1
     Tester::ANON_ENUM_VAL2.should == 2
     Tester::ANON_ENUM_VAL3.should == 5
@@ -75,11 +64,6 @@ describe "Wrapping enumerations" do
   end
 
   specify "top-level anonymous enumerations' values are added to the global scope" do
-    lambda { OUTER_ANON_1 }.should_not raise_error(NameError)
-    lambda { OUTER_ANON_2 }.should_not raise_error(NameError)
-    lambda { FOURTY_TWO }.should_not raise_error(NameError)
-    lambda { SEPERATE_OUTER_VALUE }.should_not raise_error(NameError)
-
     OUTER_ANON_1.should == 0
     OUTER_ANON_2.should == 1
     FOURTY_TWO.should == 42

--- a/test/extension_test.rb
+++ b/test/extension_test.rb
@@ -8,9 +8,7 @@ describe "Ruby Extension creation" do
       e.writer_mode :single
     end
 
-    lambda do
-      require "ext_test"
-    end.should_not raise_error(LoadError)
+    require "ext_test"
   end
 
   specify "should create a valid Ruby extension without a block" do
@@ -22,22 +20,18 @@ describe "Ruby Extension creation" do
     e.write
     e.compile
 
-    lambda do
-      require "ext_test"
-    end.should_not raise_error(LoadError)
+    require "ext_test"
   end
 
   specify "should properly build working dir as deep as needed" do
-    lambda do
-      path = File.join(File.expand_path(File.dirname(__FILE__)), "generated", "path1", "path2")
-      Extension.new "extension" do |e|
-        e.sources full_dir("headers/empty.h")
-        e.working_dir = path
-        e.writer_mode :single
-      end
+    path = File.join(File.expand_path(File.dirname(__FILE__)), "generated", "path1", "path2")
+    Extension.new "extension" do |e|
+      e.sources full_dir("headers/empty.h")
+      e.working_dir = path
+      e.writer_mode :single
+    end
 
-      File.exists?(File.join(path, "extconf.rb")).should be_true
-    end.should_not raise_error(Errno::ENOENT)
+    File.exists?(File.join(path, "extconf.rb")).should eq(true)
   end
 end
 

--- a/test/file_writers_test.rb
+++ b/test/file_writers_test.rb
@@ -26,15 +26,15 @@ describe "Multiple file writer (default)" do
       extconf.rb
       _Mod.rb.cpp
       _Mod.rb.hpp
-      _classes_Adder.rb.cpp
-      _classes_Adder.rb.hpp
-      _classes_IntAdder.rb.cpp
-      _classes_IntAdder.rb.hpp
-      _classes_ShouldFindMe.rb.hpp
-      _classes_ShouldFindMe.rb.cpp
+      __classes_Adder.rb.cpp
+      __classes_Adder.rb.hpp
+      __classes_IntAdder.rb.cpp
+      __classes_IntAdder.rb.hpp
+      __classes_ShouldFindMe.rb.hpp
+      __classes_ShouldFindMe.rb.cpp
       adder.rb.cpp
     ).each do |wants|
-      files.find {|got| File.basename(got) == wants }.should_not be_nil
+      files.find {|got| File.basename(got) == wants }.should_not be_nil, "Expected #{wants} to exist"
     end
   end
 

--- a/test/file_writers_test.rb
+++ b/test/file_writers_test.rb
@@ -116,8 +116,6 @@ describe "Single file writer with to_from_ruby" do
   end
 
   specify "should have compiled properly" do
-    lambda do
-      require 'to_from_ruby'
-    end.should_not raise_error(LoadError)
+    require 'to_from_ruby'
   end
 end

--- a/test/function_pointer_test.rb
+++ b/test/function_pointer_test.rb
@@ -20,7 +20,7 @@ describe "properly handles and wraps function pointer arguments" do
 
     call_callback
 
-    proc_called.should be_true
+    proc_called.should eq(true)
   end
 
   specify "arguments, no return" do

--- a/test/functions_test.rb
+++ b/test/functions_test.rb
@@ -10,7 +10,7 @@ describe "Extension with globally available functions" do
 
     require 'functions'
 
-    lambda { test1 }.should_not raise_error(NameError)
+    test1
 
     test2(2.0).should be_within(0.001).of(1.0)
 

--- a/test/headers/Adder.h
+++ b/test/headers/Adder.h
@@ -5,8 +5,6 @@
 using namespace std;
 
 namespace classes {
-  class Forwarder;
-
   class Adder {
     public:
       Adder();

--- a/test/implicit_cast_test.rb
+++ b/test/implicit_cast_test.rb
@@ -6,7 +6,7 @@ describe "Specify types to allow implicit casting" do
     Extension.new "implicit_cast" do |e|
       e.sources full_dir("headers/implicit_cast.h")
       e.writer_mode :single
-        
+
       node = e.namespace "implicit_cast"
 
       # Can flag individual constructors
@@ -25,16 +25,16 @@ describe "Specify types to allow implicit casting" do
   end
 
   specify "can use Degree in place of Radian" do
-    is_obtuse(Degree.new(75)).should be_false
+    is_obtuse(Degree.new(75)).should eq(false)
   end
 
   specify "can use Radian in place of Degree" do
-    is_acute(Radian.new(2.0)).should be_false
+    is_acute(Radian.new(2.0)).should eq(false)
   end
 
   specify "pointers also work fine" do
-    is_right(Degree.new(90)).should be_true
-    is_right(Radian.new(2.0)).should be_false
+    is_right(Degree.new(90)).should eq(true)
+    is_right(Radian.new(2.0)).should eq(false)
   end
 end
 

--- a/test/modules_test.rb
+++ b/test/modules_test.rb
@@ -42,28 +42,21 @@ describe "Extension with modules" do
   end
 
   specify "should be able to generate a module definition" do
-    lambda { Empty }.should_not raise_error(NameError)
-
     Empty.class.should == Module
   end
 
   specify "should wrap up C++ classes under the namespace as requested" do
-    lambda { Adder }.should raise_error(NameError)
-    lambda { Wrapper::Adder }.should_not raise_error(NameError)
-
     a = Wrapper::Adder.new
     a.get_class_name.should == "Adder"
   end
 
   specify "should wrap up C++ functions in the module" do
-    lambda { Functions }.should_not raise_error(NameError)
     Functions::test2(2).should be_within(0.001).of(1.0)
     Functions::test3(4, 6).should == 4
   end
 
   specify "should be able to nest modules and related definitions" do
     lambda { Subtracter }.should raise_error(NameError)
-    lambda { Nested::Nested::Inner::Subtracter }.should_not raise_error(NameError)
 
     s = Nested::Nested::Inner::Subtracter.new
     s.get_class_name.should == "Subtracter"

--- a/test/nested_test.rb
+++ b/test/nested_test.rb
@@ -11,12 +11,6 @@ describe "Wrapping Classes within classes" do
   end
 
   specify "should properly make nested classes available" do
-    lambda do 
-      Kernel.const_get(TestClass) 
-      Kernel.const_get(TestClass::InnerClass) 
-      Kernel.const_get(TestClass::InnerClass::Inner2) 
-    end.should_not raise_error(NameError)
-
     TestClass.new.should_not be_nil
     TestClass::InnerClass.new.should_not be_nil
     TestClass::InnerClass::Inner2.new.should_not be_nil

--- a/test/overloading_test.rb
+++ b/test/overloading_test.rb
@@ -19,26 +19,21 @@ describe "Extension with overloaded methods" do
     require 'overload'
 
     #Constructor overloading is broken in rice
-    #math = Mathy.new 
+    #math = Mathy.new
     math = Mathy.new(1)
-    
+
     math.times.should == 1
     math.times_1(3).should == 3
     math.times_2(3,2).should == 6
     math.times_3(3,2,3).should == 18
-    
-    lambda do
-      math.nothing_0
-      math.nothing_1(1)
-    end.should_not raise_error(NameError)
+
+    math.nothing_0
+    math.nothing_1(1)
 
     # Should properly handle const overloads as well
-    lambda do
-      math.const_method_0(1)
-      math.const_method_1(1)
-      math.const_method_string("love")
-    end.should_not raise_error(NameError)
-
+    math.const_method_0(1)
+    math.const_method_1(1)
+    math.const_method_string("love")
   end
 
 end

--- a/test/subclass_test.rb
+++ b/test/subclass_test.rb
@@ -25,14 +25,9 @@ describe "Extension with class hierachies" do
     # Template superclasses shouldn't cause problems
     TemplateSub.new.zero.should == TemplateSub.new.custom
 
-    lambda do
-      TemplatePtr.new.custom
-    end.should_not raise_error(NameError)
-
-    lambda do
-      Multiple.new
-    end.should_not raise_error(NameError)
-
+    # Shouldn't throw exceptions
+    TemplatePtr.new.custom
+    Multiple.new
     Multiple.superclass.should == Base2
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,6 +32,10 @@ RSpec.configure do |config|
   config.include(FileDirectoryHelpers)
   config.include(TestHelpers)
 
+  config.expect_with(:rspec) do |c|
+    c.syntax = :should
+  end
+
   config.before(:all) do
     test_setup
   end

--- a/test/wrap_as_test.rb
+++ b/test/wrap_as_test.rb
@@ -61,48 +61,36 @@ describe "Ugly interfaces cleaner" do
       ui_add(1,2)
     end.should raise_error(NoMethodError)
 
-    lambda do
-      UI::Math::add(1,2).should == 3
-    end.should_not raise_error(NoMethodError)
+    UI::Math::add(1,2).should == 3
 
     lambda do
       ui_subtract(2,1)
     end.should raise_error(NoMethodError)
 
-    lambda do
-      UI::Math::subtract(2,1).should == 1
-    end.should_not raise_error(NoMethodError)
+    UI::Math::subtract(2,1).should == 1
 
     lambda do
       C_UIVector.new
     end.should raise_error(NameError)
 
-    lambda do
-      v = UI::Vector.new
-      v.x = 3
-      v.x.should == 3
-    end.should_not raise_error(NameError)
+    v = UI::Vector.new
+    v.x = 3
+    v.x.should == 3
 
     lambda do
       UI::DMath::divide(1.0,2.0)
     end.should raise_error(NameError)
 
-    lambda do
-      UI::Modulus.mod(3,2).should == 1
-    end.should_not raise_error(NameError)
+    UI::Modulus.mod(3,2).should == 1
 
     UI::Modulus.new.method_mod(4, 3).should == 1
 
-    lambda do
-      UI::Math::divide(2,1).should == 2
-    end.should_not raise_error(NoMethodError)
+    UI::Math::divide(2,1).should == 2
 
     lambda do
       UI::NoConstructor.new
     end.should raise_error(TypeError)
 
-    lambda do
-      UI::Outside::Inside.new
-    end.should_not raise_error(NoMethodError)
+    UI::Outside::Inside.new
   end
 end

--- a/website/rbgccxml.textile
+++ b/website/rbgccxml.textile
@@ -8,7 +8,7 @@ h1. rbgccxml
 
 h3. Synopsis
 
-Rbgccxml is a C++ source code querying library. It makes use of "GCC-XML":http://www.gccxml.org and "nokogiri":http://nokogiri.org/ to process the C++ code (currently only headers and not body code) into easy to read XML, then opens up a very simple but powerful query API for searching everything about the code.
+Rbgccxml is a C++ source code querying library. It makes use of "CastXML":https://github.com/CastXML/CastXML and "nokogiri":http://nokogiri.org/ to process the C++ code (currently only headers and not body code) into easy to read XML, then opens up a very simple but powerful query API for searching everything about the code.
 
 Rbgccxml is released under the "MIT Licence":http://github.com/jameskilton/rbgccxml/tree/master/MIT_LICENCE
 


### PR DESCRIPTION
A few new default CXXFLAGS to ensure proper working with clang++ when
parsing, and updated some template output to work around a parser error
when it sees `<::`.

Related RbGCCXML PR https://github.com/jasonroelofs/rbgccxml/pull/17